### PR TITLE
Use erlang:system_time/1 in splay_ms/1

### DIFF
--- a/src/telemetry_forwarder.erl
+++ b/src/telemetry_forwarder.erl
@@ -109,7 +109,7 @@ push(true) ->
 -spec(splay_ms() -> integer()).
 splay_ms() ->
   MsPerMinute = telemetry_config:interval_seconds() * 1000,
-  NextMinute = -1 * erlang:monotonic_time(milli_seconds) rem MsPerMinute,
+  NextMinute = MsPerMinute - erlang:system_time(millisecond) rem MsPerMinute,
 
   SplayMS = telemetry_config:splay_seconds() * 1000,
   FlooredSplayMS = max(1, SplayMS),


### PR DESCRIPTION
monotonic_time/1 returns negative number on linux x86_64 and positive
number on linux armv7 or windows. For more information please see
http://erlang.org/doc/apps/erts/time_correction.html